### PR TITLE
Update gantt_chart_resource.js

### DIFF
--- a/force-app/main/default/lwc/gantt_chart_resource/gantt_chart_resource.js
+++ b/force-app/main/default/lwc/gantt_chart_resource/gantt_chart_resource.js
@@ -237,10 +237,7 @@ export default class GanttChartResource extends LightningElement {
       };
 
       self.resource.allocationsByProject[projectId].forEach(allocation => {
-        allocation.class = self.calcClass(allocation);
-        allocation.style = self.calcStyle(allocation);
-        allocation.labelStyle = self.calcLabelStyle(allocation);
-
+        allocation = {class: self.calcClass(allocation), style: self.calcStyle(allocation), labelStyle: self.calcLabelStyle(allocation)};
         project.allocations.push(allocation);
       });
 


### PR DESCRIPTION
Fix : uncaught typeerror: 'set' on proxy: trap returned falsish for property 'class'. On Winter 20 SFDC release