### PR TITLE
fix "'set' on proxy: trap returned falsish" error

### DIFF
--- a/force-app/main/default/lwc/gantt_chart_resource/gantt_chart_resource.js
+++ b/force-app/main/default/lwc/gantt_chart_resource/gantt_chart_resource.js
@@ -237,6 +237,7 @@ export default class GanttChartResource extends LightningElement {
       };
 
       self.resource.allocationsByProject[projectId].forEach(allocation => {
+        allocation = {...allocation}; //clone immutable object
         allocation.class = self.calcClass(allocation);
         allocation.style = self.calcStyle(allocation);
         allocation.labelStyle = self.calcLabelStyle(allocation);


### PR DESCRIPTION
the allocation object is immutable at this point, resulting in the error:
> Uncaught TypeError: 'set' on proxy: trap returned falsish for property 'class'

The change simply makes a mutable clone of the original object